### PR TITLE
Modified checkbox behaviour #45

### DIFF
--- a/components/MainDonationForm.js
+++ b/components/MainDonationForm.js
@@ -39,12 +39,20 @@ export default function MainDonationForm() {
   };
 
   const [showAll, setShowAll] = React.useState(true);
+  const mainForm = React.createRef();
   const handleClick = (event) => {
     setShowAll(!showAll);
+    if (showAll) {
+      const form = mainForm.current;
+      const inputs = form.getElementsByClassName("donate-form-checkbox");
+      for (let i = 0; i < inputs.length; i++) {
+        inputs[i].checked = false;
+      }
+    }
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} ref={mainForm}>
 <div className="p-6 mb-5 card bordered bg-base-100" data-theme="dark">
   <h2 className="card-title">Help us develop programs for:</h2>
 
@@ -57,6 +65,7 @@ export default function MainDonationForm() {
         className="toggle"
         value="Anyone in need"
         onClick={handleClick}
+        defaultChecked={false}
       />
     </label>
   </div>
@@ -66,7 +75,7 @@ export default function MainDonationForm() {
       <input
         type="checkbox"
         name="cause"
-        className="checkbox"
+        className="checkbox donate-form-checkbox"
         value="Students in Need"
         disabled={!showAll}
       />
@@ -78,7 +87,7 @@ export default function MainDonationForm() {
       <input
         type="checkbox"
         name="cause"
-        className="checkbox"
+        className="checkbox donate-form-checkbox"
         value="People of Color in Need"
         disabled={!showAll}
       />
@@ -90,7 +99,7 @@ export default function MainDonationForm() {
       <input
         type="checkbox"
         name="cause"
-        className="checkbox"
+        className="checkbox donate-form-checkbox"
         value="Immigrants in Need"
         disabled={!showAll}
       />
@@ -102,7 +111,7 @@ export default function MainDonationForm() {
       <input
         type="checkbox"
         name="cause"
-        className="checkbox"
+        className="checkbox donate-form-checkbox"
         value="Seniors in Need"
         disabled={!showAll}
       />

--- a/components/MainDonationForm.js
+++ b/components/MainDonationForm.js
@@ -38,12 +38,23 @@ export default function MainDonationForm() {
     }
   };
 
+  // showAll = true means that all the checkboxes are checked
   const [showAll, setShowAll] = React.useState(true);
+
+  // mainForm is the topmost form that is shown to the user
   const mainForm = React.createRef();
+
+  // handleClick is called via the onClick event when the user clicks 
+  // on the "Anyone in need" toggle switch
   const handleClick = (event) => {
     setShowAll(!showAll);
+
+    // If the "Anyone in need" toggle is on, we need to uncheck all the 
+    // checkboxes in the cause list
     if (showAll) {
       const form = mainForm.current;
+
+      // Loop through all the checkboxes in the cause list and uncheck them
       const inputs = form.getElementsByClassName("donate-form-checkbox");
       for (let i = 0; i < inputs.length; i++) {
         inputs[i].checked = false;
@@ -77,6 +88,9 @@ export default function MainDonationForm() {
         name="cause"
         className="checkbox donate-form-checkbox"
         value="Students in Need"
+
+        // If the "Anyone in need" toggle is on, we need to uncheck all the
+        // checkboxes in the cause list, such as this one
         disabled={!showAll}
       />
     </label>


### PR DESCRIPTION
This fixes an issue I recognised shortly after the previous PR was merged.

The checkbox behaviour was modified such that, when the `Anyone in need` option is selected, all other checkboxes will be checked. This prevents any messy donation messages, in addition to being more user-friendly. An additional class `donate-form-checkbox` was added to these elements to ensure future development of the site is not interfered with by these changes.