### PR TITLE
Fix browser caching in Main Donation Form

### DIFF
--- a/components/MainDonationForm.js
+++ b/components/MainDonationForm.js
@@ -38,8 +38,8 @@ export default function MainDonationForm() {
     }
   };
 
-  // showAll = true means that all the checkboxes are checked
-  const [showAll, setShowAll] = React.useState(true);
+  // isAnyoneInNeedToggled = stores the state of the "Anyone in need" toggle
+  const [isAnyoneInNeedToggled, setIsAnyoneInNeedToggled] = React.useState(true);
 
   // mainForm is the topmost form that is shown to the user
   const mainForm = React.createRef();
@@ -47,11 +47,11 @@ export default function MainDonationForm() {
   // handleClick is called via the onClick event when the user clicks 
   // on the "Anyone in need" toggle switch
   const handleClick = (event) => {
-    setShowAll(!showAll);
+    setIsAnyoneInNeedToggled(!isAnyoneInNeedToggled);
 
     // If the "Anyone in need" toggle is on, we need to uncheck all the 
     // checkboxes in the cause list
-    if (showAll) {
+    if (isAnyoneInNeedToggled) {
       const form = mainForm.current;
 
       // Loop through all the checkboxes in the cause list and uncheck them
@@ -76,7 +76,7 @@ export default function MainDonationForm() {
         className="toggle"
         value="Anyone in need"
         onClick={handleClick}
-        defaultChecked={false}
+        autoComplete="off"
       />
     </label>
   </div>
@@ -89,9 +89,15 @@ export default function MainDonationForm() {
         className="checkbox donate-form-checkbox"
         value="Students in Need"
 
+        // Prevents the browser from using cached checkbox states.
+        // The use of cached values caused interaction issues that were
+        // unintended.
+        autoComplete="off"
+
         // If the "Anyone in need" toggle is on, we need to uncheck all the
         // checkboxes in the cause list, such as this one
-        disabled={!showAll}
+        disabled={!isAnyoneInNeedToggled}
+        autoComplete="off"
       />
     </label>
   </div>
@@ -103,7 +109,8 @@ export default function MainDonationForm() {
         name="cause"
         className="checkbox donate-form-checkbox"
         value="People of Color in Need"
-        disabled={!showAll}
+        disabled={!isAnyoneInNeedToggled}
+        autoComplete="off"
       />
     </label>
   </div>
@@ -115,7 +122,8 @@ export default function MainDonationForm() {
         name="cause"
         className="checkbox donate-form-checkbox"
         value="Immigrants in Need"
-        disabled={!showAll}
+        disabled={!isAnyoneInNeedToggled}
+        autoComplete="off"
       />
     </label>
   </div>
@@ -127,7 +135,8 @@ export default function MainDonationForm() {
         name="cause"
         className="checkbox donate-form-checkbox"
         value="Seniors in Need"
-        disabled={!showAll}
+        disabled={!isAnyoneInNeedToggled}
+        autoComplete="off"
       />
     </label>
   </div>


### PR DESCRIPTION
The main donation form makes use of `input` elements with `type="checkbox"`. It
is common for browsers such as Mozilla Firefox to cache the state of a checkbox. 
This would lead to an issue where the user is able to toggle the `Anyone in need` item, refresh the page and the other elements will no longer be `disabled` leading to incorrect output when the Stripe donation page was shown.
This issues was not visible while running with `yarn dev` however it did appear on the
live site.

Additionally I have renamed the `showAll` value to `isAnyoneInNeedToggled` this name is longer but more representative of the actual value held. Also performed some comment cleanup as I don't think the previous comments properly represented what certain values were for.

((Side note - Sorry for the lots of small PRs, this has been an interesting learning experience for me, getting used to the GitHub PR and contribution system, while also learning new elements of React and HTML attributes.))