### PR TITLE
Fix card spacing 

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -88,7 +88,7 @@ export default function Home() {
             <div className="md:flex md:justify-center">
               <MainDonationForm />
             </div>
-            <div className="md:grid md:grid-cols-3 md:gap-5 ">
+            <div className="md:grid md:grid-cols-3 md:gap-x-8 md:gap-y-5">
               <Cards />
             </div>
             <p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -88,7 +88,7 @@ export default function Home() {
             <div className="md:flex md:justify-center">
               <MainDonationForm />
             </div>
-            <div className="md:grid md:grid-cols-3 md:gap-5 md:space-x-4 ">
+            <div className="md:grid md:grid-cols-3 md:gap-5 ">
               <Cards />
             </div>
             <p>


### PR DESCRIPTION
Card the cards were using the `md:space-x-4` class, this class has some strange
behaviour for calculating the grid gaps however it did not interact with the
first element correctly.

The cards are now slightly more cramped however the strange size discrepancy no longer exists.

This should fix #69 