### PR TITLE
Eslit add `Next`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "prettier",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "next"
   ],
   "parserOptions": {
     "ecmaFeatures": {

--- a/components/Card.js
+++ b/components/Card.js
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -6,7 +7,7 @@ function Card({ backgroundImageSource, children }) {
     <div className="card shadow-xl image-full">
       {backgroundImageSource && (
         <figure>
-          <img src={backgroundImageSource} />
+          <Image alt="" src={backgroundImageSource} />
         </figure>
       )}
       <div className="card-body justify-end space-y-3">{children}</div>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -12,7 +12,7 @@ export default function Footer() {
       <p>
         <a href="https://vercel.com?utm_source=margaritahumanitarian&utm_campaign=oss">
           <Image
-            alt="Powered by vercel"
+            alt="Powered by Vercel"
             height="44"
             src="/images/powered-by-vercel.svg"
             width="212"

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -12,6 +12,7 @@ export default function Footer() {
       <p>
         <a href="https://vercel.com?utm_source=margaritahumanitarian&utm_campaign=oss">
           <Image
+            alt="Powered by vercel"
             height="44"
             src="/images/powered-by-vercel.svg"
             width="212"


### PR DESCRIPTION
Resolving #103 

- Added `Next` ESLint plugin.
- Fixed new linting errors.
    - Alt text added to the `Powered by vercel` image in the `Footer`.
    - Empty `alt` text added to the `Card` component, it may be desirable to expose this as a property of the component.
