### PR TITLE
Improve mobile responsivity

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 function Card({ backgroundImageSource, children }) {
   return (
-    <div className="card shadow-xl image-full">
+    <div className="card shadow-xl image-full mb-5">
       {backgroundImageSource && (
         <figure>
           <Image alt="" layout="fill" src={backgroundImageSource} />

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 export default function Navbar() {
   return (
-    <div className="navbar mb-2 shadow-lg bg-neutral text-neutral-content">
+    <div className="navbar mb-2 shadow-lg bg-neutral text-neutral-content overflow-hidden">
       <div className="flex-none px-2 mx-2">
         <span className="text-lg font-bold">
           {'Margarita Humanitarian Foundation'}

--- a/styles/global.css
+++ b/styles/global.css
@@ -5,6 +5,7 @@
 @layer components {
   .btn {
     @apply tracking-wider shadow-2xl transform transition hover:-translate-y-0.5;
+    height: auto;
   }
 
   .shaded-text {


### PR DESCRIPTION
I've done some basic responsivity improvements, so the page looks okay.

Changes are still needed here, for example in the navbar. I added `overflow: hidden` to prevent the page shrinking due to overflowing elements. However this may hides elements such as the links to card collections, this could be remedied using some more "advanced" responsive design such as a "burger menu implementation" to allow the extra icons to be moved into a toggling list, a common feature responsive webpages. 