### PR TITLE
Fix json file import to get rid of build warnings

### DIFF
--- a/pages/electronics-gifting-cities.js
+++ b/pages/electronics-gifting-cities.js
@@ -7,7 +7,7 @@ import {
 } from 'react-google-maps';
 import React, { useState } from 'react';
 
-import * as laptopCitiesData from '../data/laptop-cities.json';
+import laptopCitiesData from '../data/laptop-cities.json';
 
 ///The MHF office at 1543 E Palmdale Blvd. Suite E, Palmdale, CA 93550 to (Default zoom)
 const MAP_CENTER_MHF_OFFICE = {


### PR DESCRIPTION
we got following warnings during build:
```
./pages/electronics-gifting-cities.js
Attempted import error: 'cities'.'map' is not exported from '../data/laptop-cities.json' (imported as 'laptopCitiesData').

./pages/electronics-gifting-cities.js
Attempted import error: 'name' is not exported from '../data/laptop-cities.json' (imported as 'laptopCitiesData').

./pages/electronics-gifting-cities.js
Attempted import error: 'cities'.'map' is not exported from '../data/laptop-cities.json' (imported as 'laptopCitiesData').

./pages/electronics-gifting-cities.js
Attempted import error: 'name' is not exported from '../data/laptop-cities.json' (imported as 'laptopCitiesData').
```

@audreyfeldroy and @ozer619 - please check if I didn't break anything ;)