### PR TITLE
Delete .github/PULL_REQUEST_TEMPLATE directory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,0 @@
-**Description**
-Please provide a summary of the changes you have made
-
-Fixes #issue


### PR DESCRIPTION
As per #194 there appears to be no reason to have this as it cannot be used in the same way that issue templates can be used. Please see the relevant self-learning discussions within the issue if you would like to read the specific details in what I was attempting and what has been shown through a trial and error process.

Closes #194