### PR TITLE
Dependabot updates

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,9 +1290,9 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
     type-fest "^0.21.3"
 
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
The Dependabot system identified the vulnerability [CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw) a ReDoS (Regular Expression Denial of Service) within the ansi-regex package. This has been identified as a moderate severity issue. Here it is a dependency of a package we use however it is still worth updating in recognition of the warning
> ansi-regex is vulnerable to Inefficient Regular Expression Complexity

suggesting that for complex Regular Expressions, the time complexity increases greater than it potentially should have leading to a DOS vulnerability. 