### PR TITLE
Add key to React.Children.map

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -99,8 +99,8 @@ export function PositionRequirements({ label, children }) {
     <div className="p-2 mt-auto shaded-text">
       <span className="font-semibold">{label}</span>
       <ul className="list-disc text-left pl-6">
-        {React.Children.map(children, (listItem) => (
-          <li>{listItem}</li>
+        {React.Children.map(children, (listItem, index) => (
+          <li key={index}>{listItem}</li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
Please don't review/merge this PR. I'm testing if DeepSource will flag JS-0437 again when I add `key` to `React.Children.map` in relation to https://github.com/margaritahumanitarian/helpafamily/pull/243/files#r723749413. 😅 