### PR TITLE
Fix Issue #265 Images stretching on Card component

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -12,6 +12,7 @@ function Card({ backgroundImageSource, backgroundImageAltText, children }) {
             alt={backgroundImageAltText}
             height="280"
             layout="responsive"
+            objectFit="cover"
             src={backgroundImageSource}
             width="400"
           />


### PR DESCRIPTION
**Fix Issue #265 Images stretching on Card component**

I added the `objectFit= "cover"` attribute to the image component and now there is no streching!

<img width="798" alt="Captura de pantalla 2021-10-07 a las 21 09 39" src="https://user-images.githubusercontent.com/77805983/136448218-36c0b963-bc6c-4930-a969-d141abf7aef1.png">

