### PR TITLE
Added revalidate for static landing page

### DIFF
--- a/pages/landing-page.js
+++ b/pages/landing-page.js
@@ -32,6 +32,7 @@ export async function getStaticProps() {
     props: {
       page: res.items[0],
     },
+    revalidate: 10,
   };
 }
 


### PR DESCRIPTION
### This PR: 
* Added revalidate option to getStaticProps
* revalidate - An optional amount in seconds after which a page re-generation can occur. Defaults to false. When revalidate is false it means that there is no revalidation, so the page will be cached as built until your next build.
* More information here https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration
* Revalidation time currently set to 10 seconds


### Self-Review Checklist
- [x] PR title is clear with proper spelling and grammar
- [x] PR description contains a bulleted list of changes contained in the PR
- [x] PR links to relevant issues, with keywords to auto-close any issues fully resolved upon merge
- [ ] All automated checks passed
- [x] Any variables introduced are named clearly and explicitly

closes #276 