### PR TITLE
Fix DeepSource Issue JS-0739 (updated)

### DIFF
--- a/components/SideNavbar.js
+++ b/components/SideNavbar.js
@@ -18,20 +18,30 @@ function SideNavbar({ show, setShow }) {
           onKeyUp={hideMenu}
           role="none"
         >
-          <Link href="/">
-            <a className="side-nav-btn">{'Home'}</a>
+          <Link href="/" passHref>
+            <a className="side-nav-btn" href="home">
+              {'Home'}
+            </a>
           </Link>
-          <Link href={Routes.InKind}>
-            <a className="side-nav-btn">{'In-Kind'}</a>
+          <Link href={Routes.InKind} passHref>
+            <a className="side-nav-btn" href="inkind">
+              {'In-Kind'}
+            </a>
           </Link>
-          <Link href={Routes.Fund}>
-            <a className="side-nav-btn">{'Fund'}</a>
+          <Link href={Routes.Fund} passHref>
+            <a className="side-nav-btn" href="fund">
+              {'Fund'}
+            </a>
           </Link>
-          <Link href={Routes.GiveYourTime}>
-            <a className="side-nav-btn">{'Give Your Time'}</a>
+          <Link href={Routes.GiveYourTime} passHref>
+            <a className="side-nav-btn" href="giveyourtime">
+              {'Give Your Time'}
+            </a>
           </Link>
-          <Link href={Routes.PartnerWithUs}>
-            <a className="side-nav-btn">{'Partner With Us'}</a>
+          <Link href={Routes.PartnerWithUs} passHref>
+            <a className="side-nav-btn" href="partnerwithus">
+              {'Partner With Us'}
+            </a>
           </Link>
         </div>
         <div className="absolute bottom-0 left-0 w-full text-center mb-2">

--- a/pages/404.js
+++ b/pages/404.js
@@ -32,7 +32,9 @@ export default function NotFound() {
                     href="https://github.com/margaritahumanitarian/helpafamily/issues/new/choose"
                     passHref
                   >
-                    <a className="text-blue-500">{'here.'}</a>
+                    <a className="text-blue-500" href="issue">
+                      {'here.'}
+                    </a>
                   </Link>
                 </p>
               </div>

--- a/pages/landing-page.js
+++ b/pages/landing-page.js
@@ -103,7 +103,7 @@ const LandingPage = ({
             <p className="mb-5">{landingPageDescription}</p>
 
             <Link href="/in-kind" passHref>
-              <a className="btn btn-accent rounded-btn" href="#">
+              <a className="btn btn-accent rounded-btn" href="inkind">
                 {'Feed A Family'}
               </a>
             </Link>


### PR DESCRIPTION
### This PR: 
Fixes #314 
* Applied `passHref` to every `<Link>` and an `href` to every `<a>` element to fix this JS-0739 issue indentified by DeepSource. Next.js overrides that `href` with the value from the `<Link>` component, so everything is fine now.
* The build fail from the previous pull request now seems to be fixed.

### Self-Review Checklist
*(put x in between the brackets to mark them completed [x])*
- [x] PR title is clear with proper spelling and grammar
- [x] PR description contains a bulleted list of changes contained in the PR
- [x] PR links to relevant issues, with keywords to auto-close any issues fully resolved upon merge
- [x] All automated checks passed
- [x] Any variables introduced are named clearly and explicitly
